### PR TITLE
[PATCH] Use mysql_config --plugindir to query the plugin directory. Also, search PATH variable for mysql_config when --with-mysql-bindir is not given. 

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -113,6 +113,43 @@ AC_SUBST(HANDLERSOCKET_SUBDIRS)
 CFLAGS="$CFLAGS -Werror"
 CXXFLAGS="$CXXFLAGS -Wall -g -fno-rtti -fno-exceptions -fPIC -DPIC"
 
+AC_CHECK_FUNC([strerror_r],
+  [
+    AC_LANG_PUSH([C++])
+    AC_MSG_CHECKING([if strerror_r is POSIX-compliant])
+    AC_TRY_COMPILE(
+      [
+#include <string.h>
+      ],
+      [
+int t = strerror_r(0, (char *)0, 0) * 2;
+      ],
+      [
+        AC_MSG_RESULT([yes])
+        AC_DEFINE([HAVE_POSIX_COMPLIANT_STRERROR_R], [1], [Define to 1 if libc has POSIX-compliant strerror_r()])
+      ],
+      [AC_MSG_RESULT([no])]
+    )
+    AC_MSG_CHECKING([if strerror_r is GNU-specific])
+    AC_TRY_COMPILE(
+      [
+#include <string.h>
+      ],
+      [
+char *t = 0;
+t = strerror_r(0, t, 0);
+      ],
+      [
+        AC_MSG_RESULT([yes])
+        AC_DEFINE([HAVE_GNU_SPECIFIC_STRERROR_R], [1], [Define to 1 if libc has GNU-compliant strerror_r()])
+      ],
+      [AC_MSG_RESULT([no])]
+    )
+    AC_LANG_POP
+  ]
+)
+  
+
 AC_CONFIG_FILES([Makefile
                  handlersocket/Makefile
                  libhsclient/Makefile

--- a/libhsclient/string_util.hpp
+++ b/libhsclient/string_util.hpp
@@ -32,6 +32,7 @@ memchr_char(char *s, int c, size_t n)
 
 string_wref get_token(char *& wp, char *wp_end, char delim);
 uint32_t atoi_uint32_nocheck(const char *start, const char *finish);
+std::string to_stdstring(const char *format, ...);
 std::string to_stdstring(uint32_t v);
 void append_uint32(string_buffer& buf, uint32_t v);
 


### PR DESCRIPTION
こんにちは。

PLUGIN_DIR を決定するのに、mysql_config が --plugindir をサポートしていればそれを使うようにするパッチを書きました。

また、このパッチでは --with-mysql-bindir が指定されていない場合に、環境変数 PATH をサーチして、mysql_config を見つけるようにしてあります。

もしよろしければマージしてくださいませ ;-)

refs:

6d301c8a7ec3cc0bf56a2b241bd44dd8bfe49bd7  Use mysql_config --plugindir to query the plugin directory.
a5c2e643809d0db7af9765a2580ba11607921ba9  Fix typo.
cdc32f8208840ffd5261e92a870f3ebb1f9d9fa3  Search PATH variable for mysql_config when --with-mysql-bindir is not given.
