### PR TITLE
Authentication support for libhsclient

### DIFF
--- a/libhsclient/hstcpcli.cpp
+++ b/libhsclient/hstcpcli.cpp
@@ -31,6 +31,7 @@ struct hstcpcli : public hstcpcli_i, private noncopyable {
   virtual bool stable_point();
   virtual void request_buf_open_index(size_t pst_id, const char *dbn,
     const char *tbl, const char *idx, const char *retflds, const char *filflds);
+  virtual void request_buf_auth(const char *secret);
   #if 0
   virtual void request_buf_find(size_t pst_id, const string_ref& op,
     const string_ref *kvs, size_t kvslen, uint32_t limit, uint32_t skip);
@@ -192,6 +193,21 @@ hstcpcli::request_buf_open_index(size_t pst_id, const char *dbn,
     writebuf.append_literal("\t");
     writebuf.append(fls_ref.begin(), fls_ref.end());
   }
+  writebuf.append_literal("\n");
+  ++num_req_bufd;
+}
+
+void
+hstcpcli::request_buf_auth(const char *secret)
+{
+  if (num_req_sent > 0 || num_req_rcvd > 0) {
+    close();
+    set_error(-1, "request_buf_auth: protocol out of sync");
+    return;
+  }
+  const string_ref secret_ref(secret, strlen(secret));
+  writebuf.append_literal("A\t1\t");
+  writebuf.append(secret_ref.begin(), secret_ref.end());
   writebuf.append_literal("\n");
   ++num_req_bufd;
 }

--- a/libhsclient/hstcpcli.hpp
+++ b/libhsclient/hstcpcli.hpp
@@ -37,6 +37,7 @@ struct hstcpcli_i {
   virtual void close() = 0;
   virtual int reconnect() = 0;
   virtual bool stable_point() = 0;
+  virtual void request_buf_auth(const char *secret) = 0;
   virtual void request_buf_open_index(size_t pst_id, const char *dbn,
     const char *tbl, const char *idx, const char *retflds,
     const char *filflds = 0) = 0;


### PR DESCRIPTION
Added authentication functions to libhsclient to support authentication configuration in HandlerSocket. This allows client libraries which use libhsclient to use the plaintext authentication function supported by HandlerSocket.
