### PR TITLE
Client library can hangs on connect more than timeout

### DIFF
--- a/libhsclient/socket.cpp
+++ b/libhsclient/socket.cpp
@@ -146,7 +146,7 @@ socket_connect(auto_file& fd, const socket_args& args, std::string& err_r)
       struct pollfd fds[1];
       int    nfds = 1;
       fds[0].fd = fd.get();
-      fds[0].events = POLLIN;
+      fds[0].events = POLLIN|POLLOUT;
       if( poll(fds,nfds, 1000*args.timeout) <= 0){
         return errno_string("connect poll", errno, err_r);
       }


### PR DESCRIPTION
Currently connect waits for tcp timeout, if blocking calls are used.
For the blocking case, I'm using non-blocking connect and poll for timeout after connect() call.
The socket became blocked after the polling.

if nonblocking parameter is set nothing is changed
