### PR TITLE
minor bugfix in perl interface: filter specification

### DIFF
--- a/perl-Net-HandlerSocket/HandlerSocket.xs
+++ b/perl-Net-HandlerSocket/HandlerSocket.xs
@@ -146,7 +146,7 @@ sv_get_string_ref(SV *sv)
 static IV
 sv_get_iv(SV *sv)
 {
-  if (sv == 0 || !SvIOK(sv) || !SvPOK(sv)) {
+  if (sv == 0 || ( !SvIOK(sv) && !SvPOK(sv) ) ) {
     return 0;
   }
   return SvIV(sv);


### PR DESCRIPTION
Also accept a string as the offset in filter specification.
The old behaviour, when passed e.g. the string '13', was to return 0. This resulted in an filterfld error from the server.
String will now be converted to int by Perl.
