### PR TITLE
Use the next MySQL handler API

### DIFF
--- a/handlersocket/database.cpp
+++ b/handlersocket/database.cpp
@@ -800,26 +800,26 @@ dbcontext::cmd_find_internal(dbcallback_i& cb, const prep_stmt& pst,
     if (is_first) {
       is_first = false;
       const key_part_map kpm = (1U << args.kvalslen) - 1;
-      r = hnd->index_read_map(table->record[0], key_buf, kpm, find_flag);
+      r = hnd->ha_index_read_map(table->record[0], key_buf, kpm, find_flag);
     } else if (args.invalues_keypart >= 0) {
       if (++invalues_idx >= args.invalueslen) {
 	break;
       }
       kplen_sum = prepare_keybuf(args, key_buf, table, kinfo, invalues_idx);
       const key_part_map kpm = (1U << args.kvalslen) - 1;
-      r = hnd->index_read_map(table->record[0], key_buf, kpm, find_flag);
+      r = hnd->ha_index_read_map(table->record[0], key_buf, kpm, find_flag);
     } else {
       switch (find_flag) {
       case HA_READ_BEFORE_KEY:
       case HA_READ_KEY_OR_PREV:
-	r = hnd->index_prev(table->record[0]);
+	r = hnd->ha_index_prev(table->record[0]);
 	break;
       case HA_READ_AFTER_KEY:
       case HA_READ_KEY_OR_NEXT:
-	r = hnd->index_next(table->record[0]);
+	r = hnd->ha_index_next(table->record[0]);
 	break;
       case HA_READ_KEY_EXACT:
-	r = hnd->index_next_same(table->record[0], key_buf, kplen_sum);
+	r = hnd->ha_index_next_same(table->record[0], key_buf, kplen_sum);
 	break;
       default:
 	r = HA_ERR_END_OF_FILE; /* to finish the loop */


### PR DESCRIPTION
This is the API currently used in MariaDB 5.2.x and newer too.

```
/Users/nox/src/mariadb-5.2.10/sql/handler.h: In member function 'void dena::dbcontext::cmd_find_internal(dena::dbcallback_i&, const dena::prep_stmt&, ha_rkey_function, const dena::cmd_exec_args&)':
/Users/nox/src/mariadb-5.2.10/sql/handler.h:1583: error: 'virtual int handler::index_read_map(uchar*, const uchar*, key_part_map, ha_rkey_function)' is protected
database.cpp:803: error: within this context
/Users/nox/src/mariadb-5.2.10/sql/handler.h:1583: error: 'virtual int handler::index_read_map(uchar*, const uchar*, key_part_map, ha_rkey_function)' is protected
database.cpp:810: error: within this context
/Users/nox/src/mariadb-5.2.10/sql/handler.h:1599: error: 'virtual int handler::index_prev(uchar*)' is protected
database.cpp:815: error: within this context
/Users/nox/src/mariadb-5.2.10/sql/handler.h:1597: error: 'virtual int handler::index_next(uchar*)' is protected
database.cpp:819: error: within this context
/Users/nox/src/mariadb-5.2.10/sql/handler.h:1605: error: 'virtual int handler::index_next_same(uchar*, const uchar*, uint)' is protected
database.cpp:822: error: within this context
make[2]: *** [handlersocket_la-database.lo] Error 1
make[1]: *** [all-recursive] Error 1
make: *** [all] Error 2
```