### PR TITLE
move remove_global_thread() out of the lock

### DIFF
--- a/handlersocket/database.cpp
+++ b/handlersocket/database.cpp
@@ -349,10 +349,12 @@ dbcontext::term_thread()
   unlock_tables_if();
   my_pthread_setspecific_ptr(THR_THD, 0);
   {
-    pthread_mutex_lock(&LOCK_thread_count);
     #if MYSQL_VERSION_ID >= 50600
     remove_global_thread(thd);
-    #else
+    #endif
+
+    pthread_mutex_lock(&LOCK_thread_count);
+    #if MYSQL_VERSION_ID < 50600
     --thread_count;
     #endif
     delete thd;


### PR DESCRIPTION
..since it locks the same mutex, causing deadlock.

This fixes https://bugs.launchpad.net/percona-server/+bug/1319904
See this comment for more details: https://bugs.launchpad.net/percona-server/+bug/1319904/comments/8