### PR TITLE
Remove auto_ptr for cxx17

### DIFF
--- a/libhsclient/hstcpcli.hpp
+++ b/libhsclient/hstcpcli.hpp
@@ -30,7 +30,11 @@ struct hstcpcli_filter {
 };
 
 struct hstcpcli_i;
-typedef std::auto_ptr<hstcpcli_i> hstcpcli_ptr;
+#if __cplusplus >= 201103L || (defined(_CPPLIB_VER) && _CPPLIB_VER >= 520)
+typedef std::unique_ptr<hstcpcli_i> hstcpcli_ptr;
+#else
+typedef std::auto_ptr<hstcpcli_i>   hstcpcli_ptr;
+#endif
 
 struct hstcpcli_i {
   virtual ~hstcpcli_i() { }


### PR DESCRIPTION
Support of compilation for >cxx11 version. auto_ptr was removed. Use unique_ptr instead