### PR TITLE
Update configure.ac

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -5,6 +5,7 @@
 AC_INIT([handlersocket-plugin], [1.1.1], [https://github.com/ahiguti/HandlerSocket-Plugin-for-MySQL/issues])
 AC_CONFIG_HEADERS([config.h])
 AM_INIT_AUTOMAKE([-Wall -Werror foreign])
+m4_ifdef([AM_PROG_AR], [AM_PROG_AR])
 AC_CONFIG_SRCDIR([libhsclient/fatal.cpp])
 AC_CONFIG_MACRO_DIR([m4])
 

--- a/libhsclient/fatal.cpp
+++ b/libhsclient/fatal.cpp
@@ -22,7 +22,7 @@ fatal_exit(const std::string& message)
 {
   fprintf(stderr, "FATAL_EXIT: %s\n", message.c_str());
   syslog(opt_syslog, "FATAL_EXIT: %s", message.c_str());
-  _exit(1);
+  _Exit(1);
 }
 
 void


### PR DESCRIPTION
- corrected error/warning "/usr/share/automake-1.16/am/ltlibrary.am: archiver requires 'AM_PROG_AR' in 'configure.ac" when running `autogen.sh`